### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/shell-escape.cabal
+++ b/shell-escape.cabal
@@ -11,7 +11,7 @@ description                   :
   Shell escaping library, offering both Bourne shell and Bash style escaping
   of ByteStrings.
 
-cabal-version                 : >= 1.6
+cabal-version                 : >= 1.8
 build-type                    : Simple
 extra-source-files            : README
                               , bench/Bench.hs


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: shell-escape.cabal:22:45: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```